### PR TITLE
ServiceManager implementation

### DIFF
--- a/bin/stock-bot.js
+++ b/bin/stock-bot.js
@@ -6,6 +6,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const stock_bot_1 = require("../lib/stock-bot");
 const chalk_1 = __importDefault(require("chalk"));
 require("../lib/util");
+const base_1 = require("../lib/base");
+const util_1 = require("../lib/util");
 const CONFIG_FILE_NAME = process.env['CONFIG_FILE'] || 'dev.js';
 const CONFIG_FILE_URL = `../conf/${CONFIG_FILE_NAME}`;
 const config = require(CONFIG_FILE_URL);
@@ -16,17 +18,10 @@ if (error) {
 }
 else {
     const service = new stock_bot_1.StockService(config);
-    service.initialize()
-        .then(() => console.log(chalk_1.default.green('StockService#initialize():SUCCESS')))
-        .catch(err => {
-        console.log(chalk_1.default.red(`An unhandled error occurred, ${err}`));
-        return service.close();
+    let serviceManager = new base_1.StockServiceManager({
+        logger: util_1.createLogger({})
     });
-    //TODO: Make the market time hook here, this way it can easily be controlled by starting and stopping the entire service. No need for the internals of the service to handle this.
-    // let serviceManager = new StockServiceManager({
-    //     logger: createLogger({})
-    // });
-    // serviceManager.monitorService(service);
+    serviceManager.monitorService(service);
 }
 //Catches unhandled Promise errors
 // process.on('unhandledRejection', () => {

--- a/bin/stock-bot.js
+++ b/bin/stock-bot.js
@@ -22,6 +22,11 @@ else {
         console.log(chalk_1.default.red(`An unhandled error occurred, ${err}`));
         return service.close();
     });
+    //TODO: Make the market time hook here, this way it can easily be controlled by starting and stopping the entire service. No need for the internals of the service to handle this.
+    // let serviceManager = new StockServiceManager({
+    //     logger: createLogger({})
+    // });
+    // serviceManager.monitorService(service);
 }
 //Catches unhandled Promise errors
 // process.on('unhandledRejection', () => {

--- a/bin/stock-bot.ts
+++ b/bin/stock-bot.ts
@@ -18,19 +18,11 @@ if (error) {
     console.error(color.red(`An error occurred when loading StockService configuration: ${error}`))
 } else {
     const service = new StockService(config);
-    service.initialize()
-    .then(() => console.log(color.green('StockService#initialize():SUCCESS')))
-    .catch(err => {
-        console.log(color.red(`An unhandled error occurred, ${err}`));
-        return service.close();
+    let serviceManager = new StockServiceManager({
+        logger: createLogger({})
     });
 
-    //TODO: Make the market time hook here, this way it can easily be controlled by starting and stopping the entire service. No need for the internals of the service to handle this.
-    // let serviceManager = new StockServiceManager({
-    //     logger: createLogger({})
-    // });
-
-    // serviceManager.monitorService(service);
+    serviceManager.monitorService(service);
 }
 
 //Catches unhandled Promise errors

--- a/bin/stock-bot.ts
+++ b/bin/stock-bot.ts
@@ -1,6 +1,8 @@
 import { StockBotOptionsValidationSchema, IStockServiceOptions, StockService } from '../lib/stock-bot';
 import color from 'chalk';
 import '../lib/util';
+import { StockServiceManager } from '../lib/base';
+import { createLogger } from '../lib/util';
 
 
 const CONFIG_FILE_NAME = process.env['CONFIG_FILE'] || 'dev.js';
@@ -22,6 +24,13 @@ if (error) {
         console.log(color.red(`An unhandled error occurred, ${err}`));
         return service.close();
     });
+
+    //TODO: Make the market time hook here, this way it can easily be controlled by starting and stopping the entire service. No need for the internals of the service to handle this.
+    // let serviceManager = new StockServiceManager({
+    //     logger: createLogger({})
+    // });
+
+    // serviceManager.monitorService(service);
 }
 
 //Catches unhandled Promise errors

--- a/conf/qa-twitter.js
+++ b/conf/qa-twitter.js
@@ -129,7 +129,12 @@ const datasource = new TwitterDataSource({
         id: '1350915232227594240',
         name: 'CoiledSpringPro',
         type: TwitterAccountType.WATCHLIST
-    }],
+    } /*, {
+        id: '1338306457511600130',
+        name: 'notmrmanziel',
+        type: TwitterAccountType.WATCHLIST
+    }*/
+    ],
     twitterKey: (process.env['TWITTER_API_KEY']),
     twitterSecret: (process.env['TWITTER_API_SECRET']),
     twitterAccessSecret: (process.env['TWITTER_ACCESS_SECRET']),

--- a/conf/test.js
+++ b/conf/test.js
@@ -1,5 +1,5 @@
 const joi = require('joi');
-const { TwitterDataSource, TwitterAccountType } = require('../lib/data-source');
+const { TwitterDataSource, TwitterAccountType, PhonyDataSource } = require('../lib/data-source');
 const { RedisDataStore, MemoryDataStore } = require('../lib/data-store');
 const path = require('path');
 const winston = require('winston');
@@ -82,7 +82,7 @@ const prometheus_registry = new PrometheusMetricRegistry({
 
 const prometheus_metric_provider = new PrometheusMetricProvider({
     logger,
-    port: 9091,
+    port: 9095,
     registry: prometheus_registry
 });
 
@@ -110,6 +110,10 @@ const DISCORD_CLIENT = new DiscordClient({
     commandPrefix: '!'
 });
 
+// const datasource = new PhonyDataSource({
+//     logger
+// });
+
 const datasource = new TwitterDataSource({
     logger,
     tickerList: t,
@@ -125,16 +129,12 @@ const datasource = new TwitterDataSource({
         name: 'CSCproALERT',
         type: TwitterAccountType.SWING_POSITION
 
-    }, {
-        id: '1350915232227594240',
-        name: 'CoiledSpringPro',
-        type: TwitterAccountType.WATCHLIST
     }],
     twitterKey: (process.env['TWITTER_API_KEY']),
     twitterSecret: (process.env['TWITTER_API_SECRET']),
     twitterAccessSecret: (process.env['TWITTER_ACCESS_SECRET']),
     twitterAccessToken: (process.env['TWITTER_ACCESS_TOKEN']),
-    scrapeProcessDelay: 60000 // 1 minute
+    scrapeProcessDelay: 15000 //15 seconds
 });
 
 // const datastore = new RedisDataStore({
@@ -145,52 +145,52 @@ const datasource = new TwitterDataSource({
 
 const datastore = new MemoryDataStore({ logger, metric: prometheus_metric_provider });
 
-const diagnostic = new DiscordDiagnosticSystem({
-    logger,
-    token: (process.env['DISCORD_API_TOKEN'] || ""),
-    guildId: (process.env['DISCORD_GUILD_ID'] || ""),
-    channelName: 'service-diagnostics',
-    client: DISCORD_CLIENT
-});
-
-// const diagnostic = new PhonyDiagnostic({
-
-// });
-
-
-// const exchange = new PhonyExchange({
+// const diagnostic = new DiscordDiagnosticSystem({
 //     logger,
+//     token: (process.env['DISCORD_API_TOKEN'] || ""),
+//     guildId: (process.env['DISCORD_GUILD_ID'] || ""),
+//     channelName: 'service-diagnostics',
+//     client: DISCORD_CLIENT
 // });
 
-const exchange = new AlpacasExchange({
-    acceptableGain: {
-        type: 'percent',
-        unit: 1
-    },
-    acceptableLoss: {
-        type: 'percent',
-        unit: 1
-    },
-    logger,
-    keyId: process.env['ALPACAS_API_KEY'],
-    secretKey: process.env['ALPACAS_SECRET_KEY'],
-    commandClient: DISCORD_CLIENT
-})
+const diagnostic = new PhonyDiagnostic({
 
-// const notification = new PhonyNotification({
-//     logger
-// });
-
-const notification = new DiscordNotification({
-    guildId: (process.env['DISCORD_GUILD_ID'] || ""),
-    logger,
-    token: (process.env['DISCORD_API_KEY'] || ""),
-    channels: {
-        "notificationChannel": "stock-notifications",
-        "socialMediaChannel": "watchlist", //TODO: This is bad, should be generic and the caller should be able to specify any channel
-    },
-    client: DISCORD_CLIENT
 });
+
+
+const exchange = new PhonyExchange({
+    logger,
+});
+
+// const exchange = new AlpacasExchange({
+//     acceptableGain: {
+//         type: 'percent',
+//         unit: 1
+//     },
+//     acceptableLoss: {
+//         type: 'percent',
+//         unit: 1
+//     },
+//     logger,
+//     keyId: process.env['ALPACAS_API_KEY'],
+//     secretKey: process.env['ALPACAS_SECRET_KEY'],
+//     commandClient: DISCORD_CLIENT
+// })
+
+const notification = new PhonyNotification({
+    logger
+});
+
+// const notification = new DiscordNotification({
+//     guildId: (process.env['DISCORD_GUILD_ID'] || ""),
+//     logger,
+//     token: (process.env['DISCORD_API_KEY'] || ""),
+//     channels: {
+//         "notificationChannel": "stock-notifications",
+//         "socialMediaChannel": "watchlist", //TODO: This is bad, should be generic and the caller should be able to specify any channel
+//     },
+//     client: DISCORD_CLIENT
+// });
 
 const serviceOptions = {
     concurrency: 1, //Should only have 1 thread here, since we want only 1 twitter connection and dont want to double process tweets

--- a/lib/base.js
+++ b/lib/base.js
@@ -22,10 +22,12 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.Worker = exports.Service = exports.promiseRetry = exports.LogLevel = void 0;
+exports.Worker = exports.Service = exports.StockServiceManager = exports.promiseRetry = exports.LogLevel = void 0;
 const bluebird_1 = __importDefault(require("bluebird"));
+const util_1 = require("util");
 const uuid = __importStar(require("uuid"));
-const util_1 = require("./util");
+const exceptions_1 = require("./exceptions");
+const util_2 = require("./util");
 var LogLevel;
 (function (LogLevel) {
     LogLevel["TRACE"] = "silly";
@@ -50,6 +52,38 @@ exports.promiseRetry = (fn, retryInterval = 3000 /* ms */, maxRetries = 5, curRe
         }
     });
 };
+class StockServiceManager {
+    constructor(options) {
+        this.logger = options.logger;
+        this.isMarketTime = false;
+        setTimeout(() => {
+            this.isMarketTime = true;
+        }, 30000);
+    }
+    monitorService(service) {
+        setTimeout(() => {
+            // isMarketTime().then(isMarketTime => {
+            bluebird_1.default.try(() => {
+                if (this.isMarketTime) {
+                    if (service.isServiceClosed()) {
+                        service.initialize()
+                            .catch(service.exceptionHandler);
+                    }
+                }
+                else {
+                    if (!service.isServiceClosed()) {
+                        service.close()
+                            .catch(service.exceptionHandler);
+                    }
+                }
+            }).catch(err => {
+                console.error(`${this.constructor.name}#monitorService():ERROR`, util_1.inspect(err));
+            })
+                .finally(() => this.monitorService(service));
+        }, 10000); //Run every 10 seconds
+    }
+}
+exports.StockServiceManager = StockServiceManager;
 /*
     We have two options here:
 
@@ -83,6 +117,9 @@ class Service {
             .then(() => this.logger.log(LogLevel.TRACE, `Started all workers for ${this.constructor.name}#initialize():SUCCESS`))
             .then(() => { });
     }
+    isServiceClosed() {
+        return this.isClosed;
+    }
     close() {
         this.isClosed = true;
         let pendingWork = [];
@@ -97,7 +134,9 @@ class Service {
             .then(() => this.logger.log(LogLevel.INFO, `${this.constructor.name}#shutdown():SUCCESS`))
             .then(() => { })
             .catch((err) => {
-            this.logger.log(LogLevel.ERROR, `${this.constructor.name}#shutdown():ERROR - ${err}`);
+            if (err.name != exceptions_1.ServiceClosed.name) {
+                this.logger.log(LogLevel.ERROR, `${this.constructor.name}#shutdown():ERROR - ${err}`);
+            }
             // Swallow error intentionally, allow service to close even with an error;
         });
     }
@@ -129,7 +168,7 @@ class Worker {
     }
     run() {
         if (this.isRunning && !this._pendingProcess && !this.isClosed) {
-            let timer = new util_1.Timer();
+            let timer = new util_2.Timer();
             timer.start();
             //TODO: this._preProcessor should not be called here, instead this._preProcessor should mostly likely be removed.
             this._pendingProcess = this._preProcessor().then((args) => this.process(args));
@@ -153,15 +192,18 @@ class Worker {
                 this.run();
             });
         }
+        else {
+            this.logger.log(LogLevel.INFO, `${this.constructor.name}#run():INVOKED - Worker is in a paused or stopped state.`);
+        }
     }
     close() {
         this.logger.log(LogLevel.INFO, `Worker ${this.id}#close():INVOKED`);
         //Since we do not manage a process, no need to wait for the process to be complete;
         this.isRunning = false;
+        this.isClosed = true;
         return bluebird_1.default.all([this._pendingProcess])
             .then(() => this.logger.log(LogLevel.INFO, `Worker ${this.id}#close():SUCCESS`))
             .then(() => {
-            this.isClosed = true;
         });
     }
 }

--- a/lib/base.js
+++ b/lib/base.js
@@ -56,31 +56,37 @@ class StockServiceManager {
     constructor(options) {
         this.logger = options.logger;
         this.isMarketTime = false;
-        setTimeout(() => {
-            this.isMarketTime = true;
-        }, 30000);
+        //NOTE: For testing and changing the values
+        // setInterval(() => {
+        //     console.log(`Setting isMarketTime to ${!this.isMarketTime}`)
+        //     this.isMarketTime = !this.isMarketTime;
+        // }, 15000);
     }
     monitorService(service) {
-        setTimeout(() => {
-            // isMarketTime().then(isMarketTime => {
-            bluebird_1.default.try(() => {
+        this.logger.log(LogLevel.INFO, `${this.constructor.name}#monitorService():INVOKED || ${service.constructor.name} is currently in ${this.isMarketTime ? 'Running' : 'Stopped'} stated`);
+        util_2.isMarketTime()
+            .then(isMarketTime => {
+            this.isMarketTime = isMarketTime;
+            return bluebird_1.default.delay(15000)
+                .then(() => bluebird_1.default.try(() => {
                 if (this.isMarketTime) {
-                    if (service.isServiceClosed()) {
-                        service.initialize()
+                    if (service.isClosed() || !service.isRunning()) {
+                        return service.initialize()
+                            .then(() => this.logger.log(LogLevel.INFO, `${this.constructor.name} has started ${service.constructor.name}`))
                             .catch(service.exceptionHandler);
                     }
                 }
                 else {
-                    if (!service.isServiceClosed()) {
-                        service.close()
+                    if (!service.isClosed() && service.isRunning()) {
+                        return service.close()
                             .catch(service.exceptionHandler);
                     }
                 }
-            }).catch(err => {
+            })).catch(err => {
                 console.error(`${this.constructor.name}#monitorService():ERROR`, util_1.inspect(err));
             })
                 .finally(() => this.monitorService(service));
-        }, 10000); //Run every 10 seconds
+        });
     }
 }
 exports.StockServiceManager = StockServiceManager;
@@ -102,10 +108,13 @@ class Service {
         //@ts-ignore
         this.workerOptions = options.workerOptions; //TODO: fix this type error; makeWorkerOptions should have it's own interface
         this.logger = options.logger;
-        this.isClosed = false;
+        this._isClosed = false;
+        this._isRunning = false;
         this.logger.log(LogLevel.INFO, `${this.constructor.name}#constructor():INVOKED`);
     }
     initialize() {
+        this._isClosed = false;
+        this._isRunning = false;
         return bluebird_1.default.try(() => {
             for (let i = 1; i <= this.concurrency; i++) {
                 const workerId = uuid.v4().substr(0, 8);
@@ -115,13 +124,18 @@ class Service {
             }
         })
             .then(() => this.logger.log(LogLevel.TRACE, `Started all workers for ${this.constructor.name}#initialize():SUCCESS`))
-            .then(() => { });
+            .then(() => {
+            this._isRunning = true;
+        });
     }
-    isServiceClosed() {
-        return this.isClosed;
+    isClosed() {
+        return this._isClosed;
+    }
+    isRunning() {
+        return this._isRunning;
     }
     close() {
-        this.isClosed = true;
+        this._isClosed = true;
         let pendingWork = [];
         this.workers.forEach(worker => {
             let workerClosingProcess = worker.close();
@@ -132,7 +146,9 @@ class Service {
         });
         return Promise.all(pendingWork)
             .then(() => this.logger.log(LogLevel.INFO, `${this.constructor.name}#shutdown():SUCCESS`))
-            .then(() => { })
+            .then(() => {
+            this._isRunning = false;
+        })
             .catch((err) => {
             if (err.name != exceptions_1.ServiceClosed.name) {
                 this.logger.log(LogLevel.ERROR, `${this.constructor.name}#shutdown():ERROR - ${err}`);
@@ -159,6 +175,7 @@ class Worker {
     }
     start() {
         this.isRunning = true;
+        this.isClosed = false;
         this.logger.log(LogLevel.TRACE, `Worker ${this.id}#start():SUCCESS`);
         this.run();
     }

--- a/lib/data-source.js
+++ b/lib/data-source.js
@@ -365,6 +365,11 @@ class TwitterDataSource extends DataSource {
             }
             this.logger.log(base_1.LogLevel.INFO, `${this.constructor.name}#startProcessing():ONTO_RECURSION`);
             return bluebird_1.default.delay(this._scrapeProcessDelay)
+                .then(() => {
+                if (this.isClosed) {
+                    return Promise.reject(new exceptions_1.ServiceClosed());
+                }
+            })
                 .then(() => this.publishLatestTweets())
                 .catch(err => {
                 this.logger.log(base_1.LogLevel.ERROR, `Error occurred when scraping Twitter: ${util_1.inspect(err)}`);
@@ -524,7 +529,8 @@ class TwitterDataSource extends DataSource {
     initialize() {
         this.isClosed = false;
         if (!this.isMock) {
-            this._scrapeProcess = this.startProcessing();
+            this._scrapeProcess = this.startProcessing()
+                .catch(err => this.logger.log(base_1.LogLevel.INFO, `${this.constructor.name}#startProcessing:ERROR -- ${util_1.inspect(err)}`));
         }
         return Promise.resolve();
     }

--- a/lib/data-source.js
+++ b/lib/data-source.js
@@ -356,11 +356,19 @@ class TwitterDataSource extends DataSource {
     constructor(options) {
         super(options);
         this.startProcessing = () => {
-            this.logger.log(base_1.LogLevel.INFO, `${this.constructor.name}#startProcessing():INVOKED`);
+            this.logger.log(base_1.LogLevel.INFO, `${this.constructor.name}#startProcessing():BEGINNING`);
+            if (this.isClosed) {
+                this.logger.log(base_1.LogLevel.INFO, `${this.constructor.name}#isClosed:TRUE - Ending Recursive Loop`);
+                //@ts-ignore
+                delete this._scrapeProcess;
+                return Promise.resolve(); //Breaks out of the recursive loop
+            }
+            this.logger.log(base_1.LogLevel.INFO, `${this.constructor.name}#startProcessing():ONTO_RECURSION`);
             return bluebird_1.default.delay(this._scrapeProcessDelay)
                 .then(() => this.publishLatestTweets())
                 .catch(err => {
                 this.logger.log(base_1.LogLevel.ERROR, `Error occurred when scraping Twitter: ${util_1.inspect(err)}`);
+                throw err;
             })
                 .finally(() => {
                 this._scrapeProcess = this.startProcessing();
@@ -389,7 +397,7 @@ class TwitterDataSource extends DataSource {
             }
             else {
                 input.forEach(account => {
-                    this.logger.log(base_1.LogLevel.INFO, util_1.inspect(account));
+                    this.logger.log(base_1.LogLevel.INFO, `input.forEach( ... ) LOG(${util_1.inspect(account)})`);
                     this.prevIds.push(account.tweets[0].id);
                     latestTweets.push({ accountId: account.accountId, tweets: [account.tweets[0]] });
                 });
@@ -500,6 +508,7 @@ class TwitterDataSource extends DataSource {
         this.twitterAccessSecret = options.twitterAccessSecret;
         this.twitterAccessToken = options.twitterAccessToken;
         this.work = [];
+        this.isClosed = false;
         this.commandClient.registerCommandHandler({
             command: 'redrive',
             description: 'Used to rerun a previous message',
@@ -513,8 +522,9 @@ class TwitterDataSource extends DataSource {
         });
     }
     initialize() {
+        this.isClosed = false;
         if (!this.isMock) {
-            this.startProcessing();
+            this._scrapeProcess = this.startProcessing();
         }
         return Promise.resolve();
     }
@@ -532,6 +542,8 @@ class TwitterDataSource extends DataSource {
         });
     }
     close() {
+        this.logger.log(base_1.LogLevel.INFO, `${this.constructor.name}#close():SUCCESS`);
+        this.isClosed = true;
         return Promise.resolve();
     }
 }

--- a/lib/diagnostic.js
+++ b/lib/diagnostic.js
@@ -75,6 +75,7 @@ class DiscordDiagnosticSystem {
         });
     }
     close() {
+        this.logger.log(base_1.LogLevel.INFO, `${this.constructor.name}:close():SUCCESS`);
         return Promise.resolve();
     }
 }

--- a/lib/diagnostic.ts
+++ b/lib/diagnostic.ts
@@ -92,6 +92,7 @@ export class DiscordDiagnosticSystem implements IDiagnostic {
 
 
     close(): Promise<void> {
+        this.logger.log(LogLevel.INFO, `${this.constructor.name}:close():SUCCESS`);
         return Promise.resolve();
     }
 }

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -237,7 +237,11 @@ class PrometheusMetricService {
         });
     }
     close() {
-        return this._stopServer();
+        this.logger.log(base_1.LogLevel.INFO, `${this.constructor.name}#close():INVOKED`);
+        return this._stopServer()
+            .then(() => {
+            this.logger.log(base_1.LogLevel.INFO, `${this.constructor.name}#close():SUCCESS`);
+        });
     }
 }
 exports.PrometheusMetricService = PrometheusMetricService;

--- a/lib/metrics.ts
+++ b/lib/metrics.ts
@@ -323,7 +323,11 @@ export class PrometheusMetricService {
     }
 
     close(): Promise<void> {
-        return this._stopServer();
+        this.logger.log(LogLevel.INFO, `${this.constructor.name}#close():INVOKED`);
+        return this._stopServer()
+        .then(() => {
+            this.logger.log(LogLevel.INFO, `${this.constructor.name}#close():SUCCESS`);
+        });
     }
 }
 

--- a/lib/notification.js
+++ b/lib/notification.js
@@ -112,12 +112,17 @@ class DiscordClient extends events_1.EventEmitter {
         });
     }
     initialize() {
-        this._client = new discord.Client();
-        return this._client.login(this.token)
-            .then(() => {
-            this._client.on('message', this._handleIncomingMessage);
-            this.logger.log(base_1.LogLevel.INFO, `${this.constructor.name}#initialize():SUCCESS`);
-        });
+        if (!this._client) {
+            this._client = new discord.Client();
+            return this._client.login(this.token)
+                .then(() => {
+                this._client.on('message', this._handleIncomingMessage);
+                this.logger.log(base_1.LogLevel.INFO, `${this.constructor.name}#initialize():SUCCESS`);
+            });
+        }
+        else {
+            return Promise.resolve();
+        }
     }
     registerCommandHandler(options) {
         const { command, handler, description, registrar, usage } = options;

--- a/lib/notification.js
+++ b/lib/notification.js
@@ -150,12 +150,13 @@ class DiscordClient extends events_1.EventEmitter {
         this.logger.log(base_1.LogLevel.INFO, `${this.constructor.name}#close():INVOKED`);
         return new Promise((resolve, reject) => {
             try {
-                this._client.destroy();
+                this._client && this._client.destroy();
                 this.logger.log(base_1.LogLevel.INFO, `${this.constructor.name}#close():SUCCESS`);
-                return resolve();
+                resolve();
             }
             catch (e) {
-                return reject(e);
+                //no-op if the client is not constructed
+                resolve();
             }
         });
     }
@@ -233,7 +234,7 @@ class DiscordNotification {
     }
     close() {
         this.logger.log(base_1.LogLevel.INFO, `${this.constructor.name}#close():SUCCESS`);
-        return Promise.resolve();
+        return this.client.close();
     }
 }
 exports.DiscordNotification = DiscordNotification;

--- a/lib/notification.js
+++ b/lib/notification.js
@@ -147,9 +147,11 @@ class DiscordClient extends events_1.EventEmitter {
         return this._client;
     }
     close() {
+        this.logger.log(base_1.LogLevel.INFO, `${this.constructor.name}#close():INVOKED`);
         return new Promise((resolve, reject) => {
             try {
                 this._client.destroy();
+                this.logger.log(base_1.LogLevel.INFO, `${this.constructor.name}#close():SUCCESS`);
                 return resolve();
             }
             catch (e) {
@@ -230,6 +232,7 @@ class DiscordNotification {
         return message.socialMediaMessage ? this.channels['socialMediaChannel'] : this.channels['notificationChannel'];
     }
     close() {
+        this.logger.log(base_1.LogLevel.INFO, `${this.constructor.name}#close():SUCCESS`);
         return Promise.resolve();
     }
 }

--- a/lib/notification.ts
+++ b/lib/notification.ts
@@ -106,14 +106,18 @@ export class DiscordClient extends EventEmitter implements CommandClient {
     }
 
     initialize(): Promise<void> {
-        this._client = new discord.Client();
+        if (!this._client) {
+            this._client = new discord.Client();
 
-        return this._client.login(this.token)
-        .then(() => {
-            this._client.on('message', this._handleIncomingMessage);
+            return this._client.login(this.token)
+            .then(() => {
+                this._client.on('message', this._handleIncomingMessage);
 
-            this.logger.log(LogLevel.INFO, `${this.constructor.name}#initialize():SUCCESS`);
-        });
+                this.logger.log(LogLevel.INFO, `${this.constructor.name}#initialize():SUCCESS`);
+            });
+        } else {
+            return Promise.resolve();
+        }
     }
 
     registerCommandHandler(options: CommandContainer): void {

--- a/lib/notification.ts
+++ b/lib/notification.ts
@@ -199,11 +199,12 @@ export class DiscordClient extends EventEmitter implements CommandClient {
         this.logger.log(LogLevel.INFO, `${this.constructor.name}#close():INVOKED`);
         return new Promise((resolve, reject) => {
             try {
-                this._client.destroy();
+                this._client && this._client.destroy();
                 this.logger.log(LogLevel.INFO, `${this.constructor.name}#close():SUCCESS`);
-                return resolve();
+                resolve();
             } catch (e) {
-                return reject(e);
+                //no-op if the client is not constructed
+                resolve();
             }
         });
     }
@@ -318,7 +319,7 @@ export class DiscordNotification implements INotification {
 
     close(): Promise<void> {
         this.logger.log(LogLevel.INFO, `${this.constructor.name}#close():SUCCESS`);
-        return Promise.resolve();
+        return this.client.close();
     }
 }
 

--- a/lib/notification.ts
+++ b/lib/notification.ts
@@ -196,9 +196,11 @@ export class DiscordClient extends EventEmitter implements CommandClient {
     }
 
     close(): Promise<void> {
+        this.logger.log(LogLevel.INFO, `${this.constructor.name}#close():INVOKED`);
         return new Promise((resolve, reject) => {
             try {
-                this._client.destroy()
+                this._client.destroy();
+                this.logger.log(LogLevel.INFO, `${this.constructor.name}#close():SUCCESS`);
                 return resolve();
             } catch (e) {
                 return reject(e);
@@ -315,6 +317,7 @@ export class DiscordNotification implements INotification {
     }
 
     close(): Promise<void> {
+        this.logger.log(LogLevel.INFO, `${this.constructor.name}#close():SUCCESS`);
         return Promise.resolve();
     }
 }

--- a/lib/stock-bot.js
+++ b/lib/stock-bot.js
@@ -18,15 +18,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -37,7 +28,6 @@ const bluebird_1 = __importDefault(require("bluebird"));
 const exception = __importStar(require("./exceptions"));
 const data_source_1 = require("./data-source");
 const joi = __importStar(require("joi"));
-const util_1 = require("./util");
 exports.StockBotOptionsValidationSchema = joi.object({
     datasource: joi.object().instance(data_source_1.DataSource).required(),
     datastore: joi.required(),
@@ -66,6 +56,7 @@ exports.StockBotOptionsValidationSchema = joi.object({
     //Winston is not actually a class
 });
 class StockService extends base_1.Service {
+    // runOnlyInMarketTime: boolean;
     constructor(options) {
         super(options);
         this.fetchWork = () => {
@@ -77,16 +68,16 @@ class StockService extends base_1.Service {
                 return base_1.promiseRetry(() => this.fetchWork());
             });
         };
-        this.handleMarketTimeProcessing = () => {
-            this.logger.log(base_1.LogLevel.INFO, `Checking if it is market time..`);
-            return util_1.isMarketTime()
-                .then((isMarketTime) => {
-                for (let worker of this.workers.values()) {
-                    //NOTE: start() and stop() are idempotent
-                    isMarketTime ? worker.start() : worker.stop();
-                }
-            });
-        };
+        // handleMarketTimeProcessing = (): Promise<void> => {
+        //     this.logger.log(LogLevel.INFO, `Checking if it is market time..`);
+        //     return isMarketTime()
+        //     .then((isMarketTime: boolean) => {
+        //         for (let worker of this.workers.values()) {
+        //             //NOTE: start() and stop() are idempotent
+        //             isMarketTime ? worker.start() : worker.close();
+        //         }
+        //     })
+        // }
         /*
             All this function does is verify that the processable work array has data in it.. this is later on called by the Worker class before process
             This should simply be a function for fetching work in a service, the only time a worker should have it process method invoked, is if there is data to supply to it.
@@ -94,7 +85,7 @@ class StockService extends base_1.Service {
             NOTE: preProcess is what workers call before calling their process() function, by checking if market time here,
             we can pause processing of the workers
         */
-        this.preProcess = () => __awaiter(this, void 0, void 0, function* () {
+        this.preProcess = () => {
             this.logger.log(base_1.LogLevel.TRACE, `${this.constructor.name}#preProcess():CALLED`);
             this.metric.push({
                 'processablesByteSize': {
@@ -150,20 +141,16 @@ class StockService extends base_1.Service {
                         this.logger.log(base_1.LogLevel.TRACE, `Nothing in this.processables, instead retrying this.preProcess()`);
                         return this.preProcess();
                     }
-                })
-                    .catch(err => {
-                    this.logger.log(base_1.LogLevel.ERROR, `this.preProcess():ERROR -> ${err}`);
-                    throw err;
                 });
             }
-        });
+        };
         this.exceptionHandler = (err) => {
-            console.log(err, JSON.stringify(err));
-            if (err.name === exception.UnprocessableTicker.name) {
+            // console.log(err, JSON.stringify(err))
+            if (err.name == exception.UnprocessableTicker.name) {
                 this.logger.log(base_1.LogLevel.WARN, `Missing properties, timing out ${err.message}`);
                 this.datasource.timeoutTicker(err.message); //Here, with that particular error, the message will be the TICKER
             }
-            else if (err.name === exception.ServiceClosed.name) {
+            else if (err.name == exception.ServiceClosed.name) {
                 //Do nothing
                 this.logger.log(base_1.LogLevel.WARN, `${this.constructor.name}#exceptionHandler - Received ServiceClosed error from Worker Process.`);
             }
@@ -197,15 +184,16 @@ class StockService extends base_1.Service {
         this.mainWorker = options.mainWorker;
         this.commandClient = options.commandClient;
         this.accountPercent = options.accountPercent;
-        this.runOnlyInMarketTime = options.runOnlyInMarketTime;
-        if (this.runOnlyInMarketTime) {
-            setTimeout(() => {
-                this.handleMarketTimeProcessing()
-                    .catch(this.exceptionHandler);
-            }, 60000); //Check every minute
-        }
+        // this.runOnlyInMarketTime = options.runOnlyInMarketTime;
+        // if (this.runOnlyInMarketTime) {
+        //     setTimeout(() => {
+        //         this.handleMarketTimeProcessing()
+        //         .catch(this.exceptionHandler)
+        //     }, 60000); //Check every minute
+        // }
     }
     initialize() {
+        this.isClosed = false;
         this.logger.log(base_1.LogLevel.INFO, `${this.constructor.name}#initialize():INVOKED`);
         return Promise.all([this.exchange.initialize(), this.notification.initialize(), this.datasource.initialize(), this.diagnostic.initialize(), this.metric.initialize(), this.commandClient.initialize()])
             .then(() => super.initialize())
@@ -217,9 +205,12 @@ class StockService extends base_1.Service {
         return new this.mainWorker(Object.assign(Object.assign({}, options), { _preProcessor: this.preProcess, exceptionHandler: this.exceptionHandler, purchaseOptions: this.purchaseOptions, exchange: this.exchange, notification: this.notification, dataSource: this.datasource, dataStore: this.datastore, metric: this.metric, accountPercent: this.accountPercent }));
     }
     close() {
-        return super.close()
-            .then(() => Promise.all([this.datasource.close(), this.diagnostic.close(), this.exchange.close(), this.notification.close(), this.metric.close(), this.commandClient.close()]))
-            .then(() => { });
+        this.logger.log(base_1.LogLevel.INFO, `${this.constructor.name}#close():INVOKED`);
+        return Promise.all([this.datasource.close(), this.diagnostic.close(), this.exchange.close(), this.notification.close(), this.metric.close(), this.commandClient.close()])
+            .then(() => super.close())
+            .then(() => {
+            this.logger.log(base_1.LogLevel.INFO, `${this.constructor.name}#close():SUCCESS`);
+        });
     }
 }
 exports.StockService = StockService;

--- a/lib/stock-bot.js
+++ b/lib/stock-bot.js
@@ -56,7 +56,6 @@ exports.StockBotOptionsValidationSchema = joi.object({
     //Winston is not actually a class
 });
 class StockService extends base_1.Service {
-    // runOnlyInMarketTime: boolean;
     constructor(options) {
         super(options);
         this.fetchWork = () => {
@@ -68,16 +67,6 @@ class StockService extends base_1.Service {
                 return base_1.promiseRetry(() => this.fetchWork());
             });
         };
-        // handleMarketTimeProcessing = (): Promise<void> => {
-        //     this.logger.log(LogLevel.INFO, `Checking if it is market time..`);
-        //     return isMarketTime()
-        //     .then((isMarketTime: boolean) => {
-        //         for (let worker of this.workers.values()) {
-        //             //NOTE: start() and stop() are idempotent
-        //             isMarketTime ? worker.start() : worker.close();
-        //         }
-        //     })
-        // }
         /*
             All this function does is verify that the processable work array has data in it.. this is later on called by the Worker class before process
             This should simply be a function for fetching work in a service, the only time a worker should have it process method invoked, is if there is data to supply to it.
@@ -93,7 +82,7 @@ class StockService extends base_1.Service {
                     labels: {}
                 }
             });
-            if (this.isClosed) {
+            if (this.isClosed()) {
                 return Promise.reject(new exception.ServiceClosed());
             }
             if (this.processables.length > 0) {
@@ -163,7 +152,7 @@ class StockService extends base_1.Service {
                         }
                     }
                 });
-                this.logger.log(base_1.LogLevel.ERROR, `Caught error in ${this.constructor.name}.exceptionHandler -> Error: ${err}`);
+                this.logger.log(base_1.LogLevel.ERROR, `Caught error in ${this.constructor.name}.exceptionHandler -> Error: ${err}::${err.stack}`);
                 this.diagnostic.alert({
                     level: base_1.LogLevel.ERROR,
                     title: 'Service Error',
@@ -184,16 +173,9 @@ class StockService extends base_1.Service {
         this.mainWorker = options.mainWorker;
         this.commandClient = options.commandClient;
         this.accountPercent = options.accountPercent;
-        // this.runOnlyInMarketTime = options.runOnlyInMarketTime;
-        // if (this.runOnlyInMarketTime) {
-        //     setTimeout(() => {
-        //         this.handleMarketTimeProcessing()
-        //         .catch(this.exceptionHandler)
-        //     }, 60000); //Check every minute
-        // }
     }
     initialize() {
-        this.isClosed = false;
+        // this._isClosed = false;
         this.logger.log(base_1.LogLevel.INFO, `${this.constructor.name}#initialize():INVOKED`);
         return Promise.all([this.exchange.initialize(), this.notification.initialize(), this.datasource.initialize(), this.diagnostic.initialize(), this.metric.initialize(), this.commandClient.initialize()])
             .then(() => super.initialize())

--- a/lib/stock-bot.ts
+++ b/lib/stock-bot.ts
@@ -94,7 +94,6 @@ export class StockService extends Service<BaseStockEvent, BaseStockEvent> {
     notification: INotification;
     commandClient: CommandClient;
     accountPercent: number;
-    // runOnlyInMarketTime: boolean;
 
     constructor(options: IStockServiceOptions) {
         super(options);
@@ -108,18 +107,10 @@ export class StockService extends Service<BaseStockEvent, BaseStockEvent> {
         this.mainWorker = options.mainWorker;
         this.commandClient = options.commandClient;
         this.accountPercent = options.accountPercent;
-        // this.runOnlyInMarketTime = options.runOnlyInMarketTime;
-
-        // if (this.runOnlyInMarketTime) {
-        //     setTimeout(() => {
-        //         this.handleMarketTimeProcessing()
-        //         .catch(this.exceptionHandler)
-        //     }, 60000); //Check every minute
-        // }
     }
 
     initialize(): Promise<void> {
-        this.isClosed = false;
+        // this._isClosed = false;
         this.logger.log(LogLevel.INFO, `${this.constructor.name}#initialize():INVOKED`);
         return Promise.all([ this.exchange.initialize(), this.notification.initialize(), this.datasource.initialize(), this.diagnostic.initialize(), this.metric.initialize(), this.commandClient.initialize() ])
         .then(() => super.initialize())
@@ -137,17 +128,6 @@ export class StockService extends Service<BaseStockEvent, BaseStockEvent> {
             return promiseRetry(() => this.fetchWork());
         });
     }
-
-    // handleMarketTimeProcessing = (): Promise<void> => {
-    //     this.logger.log(LogLevel.INFO, `Checking if it is market time..`);
-    //     return isMarketTime()
-    //     .then((isMarketTime: boolean) => {
-    //         for (let worker of this.workers.values()) {
-    //             //NOTE: start() and stop() are idempotent
-    //             isMarketTime ? worker.start() : worker.close();
-    //         }
-    //     })
-    // }
 
     /*
         All this function does is verify that the processable work array has data in it.. this is later on called by the Worker class before process
@@ -167,7 +147,7 @@ export class StockService extends Service<BaseStockEvent, BaseStockEvent> {
             }
         });
 
-        if (this.isClosed) {
+        if (this.isClosed()) {
             return Promise.reject(new exception.ServiceClosed());
         }
 
@@ -256,7 +236,7 @@ export class StockService extends Service<BaseStockEvent, BaseStockEvent> {
                 }
             })
 
-            this.logger.log(LogLevel.ERROR, `Caught error in ${this.constructor.name}.exceptionHandler -> Error: ${err}`);
+            this.logger.log(LogLevel.ERROR, `Caught error in ${this.constructor.name}.exceptionHandler -> Error: ${err}::${err.stack}`);
             this.diagnostic.alert({
                 level: LogLevel.ERROR,
                 title: 'Service Error',

--- a/test/data-source.js
+++ b/test/data-source.js
@@ -185,4 +185,6 @@ describe('#TwitterDataSource', () => {
         chai.expect(output1[1].tweets[0]).deep.equal(input1[1].tweets[0]);
         chai.expect(twitterDataSource['prevIds']).deep.equal(["TEST", input1[0].tweets[0].id, input1[1].tweets[0].id]);
     }));
+    it('Can close, and stop recursion properly', () => {
+    });
 });

--- a/test/data-source.ts
+++ b/test/data-source.ts
@@ -184,4 +184,8 @@ describe('#TwitterDataSource', () => {
 
         chai.expect(twitterDataSource['prevIds']).deep.equal(["TEST", input1[0].tweets[0].id, input1[1].tweets[0].id]);
     });
+
+    it('Can close, and stop recursion properly', () => {
+        
+    });
 });

--- a/test/stock-bot.js
+++ b/test/stock-bot.js
@@ -96,7 +96,7 @@ let worker;
 describe('#StockService', () => {
     it('Can create a StockService instance', () => {
         service = new stock_bot_1.StockService(serviceOptions);
-        service.isClosed = true; //Blocks preProcess from recursively running
+        service._isClosed = true; //Blocks preProcess from recursively running
         assert.strictEqual(service instanceof stock_bot_1.StockService, true, 'service is not StockService');
     });
     //Need to find a better way to test this
@@ -120,7 +120,7 @@ describe('#StockService', () => {
                 return data;
             });
         };
-        service.isClosed = false;
+        service._isClosed = false;
         service.logger.log(base_1.LogLevel.INFO, `service.process() called below me`);
         return service.fetchWork() //Fill this.processables
             .then(() => service.preProcess()) //Make sure the work passes through the filter logic
@@ -136,7 +136,7 @@ describe('#StockService', () => {
             });
         })
             .then(() => {
-            service.isClosed = false;
+            service._isClosed = false;
         })
             .then(() => service.preProcess())
             .then(work => {

--- a/test/stock-bot.ts
+++ b/test/stock-bot.ts
@@ -84,7 +84,7 @@ let worker: TopGainerNotificationStockWorker;
 describe('#StockService', () => {
     it('Can create a StockService instance', () => {
         service = new StockService(serviceOptions);
-        service.isClosed = true; //Blocks preProcess from recursively running
+        service._isClosed = true; //Blocks preProcess from recursively running
         assert.strictEqual(service instanceof StockService, true, 'service is not StockService');
     });
 
@@ -113,7 +113,7 @@ describe('#StockService', () => {
             })
         }
 
-        service.isClosed = false;
+        service._isClosed = false;
         service.logger.log(LogLevel.INFO, `service.process() called below me`)
         return service.fetchWork() //Fill this.processables
         .then(() => service.preProcess()) //Make sure the work passes through the filter logic
@@ -129,7 +129,7 @@ describe('#StockService', () => {
             });
         })
         .then(() => {
-            service.isClosed = false;
+            service._isClosed = false;
         })
         .then(() => service.preProcess())
         .then(work => {


### PR DESCRIPTION
Added a `ServiceManager` class, which now takes a generic `IService` implementation, and can start and stop it depending on if it is currently market time or not. 

There are some small fixes to other classes as well here since there was a small bug with how many callers of `DiscordClient#initialize()` there was. Probably should make that idempotent.